### PR TITLE
Formalize dependency on R 4.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,8 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
-URL: https://github.com/MilesMcBain/paint-
-BugReports: https://github.com/MilesMcBain/paint-/issues
+URL: https://github.com/MilesMcBain/paint
+BugReports: https://github.com/MilesMcBain/paint/issues
 Depends:
     R (>= 4.1.0)
 Imports: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,8 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 URL: https://github.com/MilesMcBain/paint-
 BugReports: https://github.com/MilesMcBain/paint-/issues
+Depends:
+    R (>= 4.1.0)
 Imports: 
     crayon,
     keypress,


### PR DESCRIPTION
If only to warn those of us who are stuck using older versions of R a little earlier.